### PR TITLE
fix peer list retreival

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -24,7 +24,9 @@ var cli = meow({
 io.on('connection', function(socket){
     socket.on('join', function(room) {
       // Get the list of peers in the room
-      var peers = Object.keys(io.nsps['/'].adapter.rooms['foobar'] || {});
+      var peers = io.nsps['/'].adapter.rooms[room] ?
+                Object.keys(io.nsps['/'].adapter.rooms[room].sockets) : {}
+      
       // Send them to the client
       socket.emit('peers', peers);
       // And then add the client to the room

--- a/bin/index.js
+++ b/bin/index.js
@@ -25,7 +25,7 @@ io.on('connection', function(socket){
     socket.on('join', function(room) {
       // Get the list of peers in the room
       var peers = io.nsps['/'].adapter.rooms[room] ?
-                Object.keys(io.nsps['/'].adapter.rooms[room].sockets) : {}
+                Object.keys(io.nsps['/'].adapter.rooms[room].sockets) : []
       
       // Send them to the client
       socket.emit('peers', peers);


### PR DESCRIPTION
this also fixes #3 

The previous code was returning `['sockets', 'length']`  for the `Object.keys` on the room. The `sockets` key is a proper list of socket ids.  This may have changed from a version bump in socket.io.